### PR TITLE
Don't export symbols or synthetic object files in Scratchbox

### DIFF
--- a/0009-Dont-export-symbols.patch
+++ b/0009-Dont-export-symbols.patch
@@ -1,0 +1,29 @@
+diff --git a/compiler/rustc_codegen_ssa/src/back/link.rs b/compiler/rustc_codegen_ssa/src/back/link.rs
+index dd9d277..04d1a21 100644
+--- a/compiler/rustc_codegen_ssa/src/back/link.rs
++++ b/compiler/rustc_codegen_ssa/src/back/link.rs
+@@ -1904,6 +1904,10 @@ fn add_linked_symbol_object(
+         return;
+     };
+
++    if std::env::var("SB2_RUST_TARGET_TRIPLE").is_ok() {
++        return;
++    }
++
+     if file.format() == object::BinaryFormat::Coff {
+         // NOTE(nbdd0121): MSVC will hang if the input object file contains no sections,
+         // so add an empty section.
+diff --git a/compiler/rustc_codegen_ssa/src/back/linker.rs b/compiler/rustc_codegen_ssa/src/back/linker.rs
+index 0943451..1e14c79 100644
+--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
++++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
+@@ -669,6 +669,10 @@ impl<'a> Linker for GccLinker<'a> {
+             return;
+         }
+
++        if std::env::var("SB2_RUST_TARGET_TRIPLE").is_ok() {
++            return;
++        }
++
+         let is_windows = self.sess.target.is_like_windows;
+         let path = tmpdir.join(if is_windows { "list.def" } else { "list" });

--- a/rust.spec
+++ b/rust.spec
@@ -77,6 +77,7 @@ Patch5: 0005-Provide-ENV-controls-to-bypass-some-sb2-calls-betwee.patch
 Patch6: 0006-Scratchbox2-needs-to-be-able-to-tell-cargo-the-defau.patch
 Patch7: 0007-Disable-aarch64-outline-atomics-for-now.patch
 Patch8: 0008-Revert-Use-statx-s-64-bit-times-on-32-bit-linux-gnu.patch
+Patch9: 0009-Dont-export-symbols.patch
 # This is the real rustc spec - the stub one appears near the end.
 %ifarch %ix86
 


### PR DESCRIPTION
It evidently looks like the linker in Scratchbox / Sailfish SDK does not work with - nor need - the exported symbols and synthetic object files. Taking inspiration of the plain if-return just above the patch lines, I added a detection of `SB2_RUST_TARGET_TRIPLE` environment variable, which then results in those files not being created, and thus not being added to the linker file list.

With this patch Rust 1.75.0 compiles in Platform SDK shell (the hanging problem in the build target still exists - `statx` syscall is the main culprit) and installing the resulting packages into Sailfish SDK successfully lets me build Whisperfish 1.72 branch for i486, armv7hl and aarch64. The functionality of the armv7hl build was tested on-device with Jolla Phone, and it seems to work just fine (as a test I sent a message and checked the output on terminal).

This patch is kind of a hack, but then again, so are many of the other patches. Further improvements are most welcome!