### PR TITLE
Use `$HOME/.tmp` as temp dir if `TMPDIR` is unset

### DIFF
--- a/0009-Relocate-unset-tmp.patch
+++ b/0009-Relocate-unset-tmp.patch
@@ -1,0 +1,49 @@
+diff --git a/compiler/rustc_codegen_ssa/src/back/link.rs b/compiler/rustc_codegen_ssa/src/back/link.rs
+index dd9d277fb..160e472cf 100644
+--- a/compiler/rustc_codegen_ssa/src/back/link.rs
++++ b/compiler/rustc_codegen_ssa/src/back/link.rs
+@@ -48,7 +48,7 @@ use std::ffi::OsString;
+ use std::fs::{read, File, OpenOptions};
+ use std::io::{BufWriter, Write};
+ use std::ops::Deref;
+-use std::path::{Path, PathBuf};
++use std::path::{MAIN_SEPARATOR, Path, PathBuf};
+ use std::process::{ExitStatus, Output, Stdio};
+ use std::{env, fmt, fs, io, mem, str};
+ 
+@@ -95,11 +95,24 @@ pub fn link_binary<'a>(
+         });
+ 
+         if outputs.outputs.should_link() {
++            let mut clear_tmp = false;
++            if env::var_os("TMPDIR").is_none() && env::var_os("HOME").is_some() {
++                let home_tmp = env::var_os("HOME").unwrap();
++                let home_tmp = format!("{}{}{}", home_tmp.to_string_lossy(), MAIN_SEPARATOR, ".tmp");
++                env::set_var("TMPDIR", &home_tmp);
++                if !Path::new(&home_tmp).exists() {
++                    let _ = fs::create_dir_all(home_tmp);
++                }
++                clear_tmp = true;
++            }
+             let tmpdir = TempFileBuilder::new()
+                 .prefix("rustc")
+                 .tempdir()
+                 .unwrap_or_else(|error| sess.emit_fatal(errors::CreateTempDir { error }));
+             let path = MaybeTempDir::new(tmpdir, sess.opts.cg.save_temps);
++            if clear_tmp {
++                env::remove_var("TMP");
++            }
+             let output = out_filename(
+                 sess,
+                 crate_type,
+@@ -1904,6 +1917,10 @@ fn add_linked_symbol_object(
+         return;
+     };
+ 
++    if std::env::var("SB2_RUST_TARGET_TRIPLE").is_ok() {
++        return;
++    }
++
+     if file.format() == object::BinaryFormat::Coff {
+         // NOTE(nbdd0121): MSVC will hang if the input object file contains no sections,
+         // so add an empty section.

--- a/rust.spec
+++ b/rust.spec
@@ -77,6 +77,7 @@ Patch5: 0005-Provide-ENV-controls-to-bypass-some-sb2-calls-betwee.patch
 Patch6: 0006-Scratchbox2-needs-to-be-able-to-tell-cargo-the-defau.patch
 Patch7: 0007-Disable-aarch64-outline-atomics-for-now.patch
 Patch8: 0008-Revert-Use-statx-s-64-bit-times-on-32-bit-linux-gnu.patch
+Patch9: 0009-Relocate-unset-tmp.patch
 # This is the real rustc spec - the stub one appears near the end.
 %ifarch %ix86
 


### PR DESCRIPTION
When Rust is determining the temp directory to use during compilation, `tempfile` uses `env::temp_dir()` which in *nix [returns /tmp if TMPDIR is unset](https://doc.rust-lang.org/src/std/sys/unix/os.rs.html#685). This leads to a situation where the linker can't find `symbols.o` file during the linking phase.

This could be mitigated already by setting `TMPDIR` in a .spec file, but this needs to be done in every project separately. Instead, make the compiler default to `$HOME/.tmp` if `TMPDIR` is unset instead. The patch uses `$HOME`, which exists in both Sailfish SDK and Platform SDK.

Patching how `env::temp_dir()` works in `std` feels overkill and could lead to other issues. Hence this patch targets the compiler itself during compiling and linking.

With Rust packages compiled with this patch, Whisperfish was able to compile without errors without the `TMPDIR` commands in the .spec file.