### PR TITLE
Remove leftover code from previous attempt

### DIFF
--- a/0009-Relocate-unset-tmp.patch
+++ b/0009-Relocate-unset-tmp.patch
@@ -36,14 +36,3 @@ index dd9d277fb..160e472cf 100644
              let output = out_filename(
                  sess,
                  crate_type,
-@@ -1904,6 +1917,10 @@ fn add_linked_symbol_object(
-         return;
-     };
- 
-+    if std::env::var("SB2_RUST_TARGET_TRIPLE").is_ok() {
-+        return;
-+    }
-+
-     if file.format() == object::BinaryFormat::Coff {
-         // NOTE(nbdd0121): MSVC will hang if the input object file contains no sections,
-         // so add an empty section.


### PR DESCRIPTION
I didn't review the patch closely when I made the pull request, so remnants of some previous attempt to fix the temp directory issue slipped in. Those removed lines were just plain wrong and shouldn't be there.

This correct patch has received a full rebuild, installation to my SFDK and Whisperfish recompilation without its TMPDIR workaround in the .spec file, and it all went without issues.